### PR TITLE
fix(TS): onTouchDown should be onTouchStart

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ export function withGesture(config: GestureOptions)
 
 type GestureEvents = {
     onMouseDown?: React.MouseEventHandler;
-    onTouchDown?: React.TouchEventHandler;
+    onTouchStart?: React.TouchEventHandler;
 }
 
 export function useGesture(): [(...args: any[]) => GestureEvents, GestureState]


### PR DESCRIPTION
Ran into this while writing some code to override when to forward the events. Solid work on this library btw 👍 