### PR TITLE
Reintroduce onMove, onDown and onUp callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ withGesture(config)(Component)
   mouse: true,                  // accept mouse input
   passive: { passive: true },   // event handler 3rd argument input, passive by default
   onAction: undefined           // event => eventHandler, respond to events outside Reacts render cycle
+  onMove: undefined             // event => eventHandler, respond to mousemove/touchmove events within Reacts render cycle
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ withGesture(config)(Component)
   touch: true,                  // accept touch input
   mouse: true,                  // accept mouse input
   passive: { passive: true },   // event handler 3rd argument input, passive by default
-  onAction: undefined           // event => eventHandler, respond to events outside Reacts render cycle
-  onMove: undefined             // event => eventHandler, respond to mousemove/touchmove events within Reacts render cycle
+  onAction: undefined           // event => eventHandler, respond to events outside React's render cycle
+  onMove: undefined             // event => eventHandler, respond to mousemove/touchmove events within React's render cycle
+  onUp: undefined               // event => eventHandler, respond to mouseup/touchend events within React's render cycle
+  onDown: undefined             // event => eventHandler, respond to touchstart/mousedown events within React's render cycle
 }
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,8 @@ export interface GestureOptions {
 
     onAction?(state: GestureState): any;
     onMove?(state: GestureState): any;
+    onUp?(state: GestureState): any;
+    onDown?(state: GestureState): any;
 }
 
 export interface GestureProps {

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,7 @@ export interface GestureOptions {
     passive?: boolean | AddEventListenerOptions;
 
     onAction?(state: GestureState): any;
+    onMove?(state: GestureState): any;
 }
 
 export interface GestureProps {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,15 @@ const touchMove = 'touchmove'
 const touchEnd = 'touchend'
 const mouseMove = 'mousemove'
 const mouseUp = 'mouseup'
-const defaultProps = { touch: true, mouse: true, passive: { passive: true } }
+const defaultProps = {
+  touch: true,
+  mouse: true,
+  passive: { passive: true },
+  onAction: undefined,
+  onDown: undefined,
+  onUp: undefined,
+  onMove: undefined
+}
 const initialState = {
   event: undefined,
   args: undefined,
@@ -34,6 +42,7 @@ function handlers(set, props = {}, args) {
     set(state => {
       const newProps = { ...state, down: false, first: false }
       const temp = props.onAction && props.onAction(newProps)
+      if (props.onUp) props.onUp(newProps)
       return {
         ...newProps,
         event,
@@ -66,6 +75,7 @@ function handlers(set, props = {}, args) {
         },
       }
       const temp = props.onAction && props.onAction(newProps)
+      if (props.onDown) props.onDown(newProps)
       return { ...newProps, temp }
     })
   }
@@ -158,9 +168,14 @@ class Gesture extends React.Component {
     onAction: PropTypes.func,
     /** Optional. Provides a callback on touchmove and mousemove events. */
     onMove: PropTypes.func,
+    /** Optional. Provides a callback on mouseup and touchend events. */
+    onUp: PropTypes.func,
+    /** Optional. Provides a callback on touchstart and mousedown events. */
+    onDown: PropTypes.func,
     /** Optional. addEventListener 3rd arg config, { passive: true } by default, should be false if you plan to call event.preventDefault() or event.stopPropagation() */
     passive: PropTypes.any,
   }
+
   static defaultProps = defaultProps
 
   constructor(props) {

--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ function handlers(set, props = {}, args) {
         first: false,
       }
       const temp = props.onAction && props.onAction(newProps)
+      if (props.onMove) props.onMove(newProps)
       return { ...newProps, temp: temp || newProps.temp }
     })
   }
@@ -155,6 +156,8 @@ class Gesture extends React.Component {
     /** Optional. Calls back on mouse or touch down/up/move. When this is given it will manage state outside of React,
      * in this case it will never cause a new render, clients have to rely on callbacks to get notified. */
     onAction: PropTypes.func,
+    /** Optional. Provides a callback on touchmove and mousemove events. */
+    onMove: PropTypes.func,
     /** Optional. addEventListener 3rd arg config, { passive: true } by default, should be false if you plan to call event.preventDefault() or event.stopPropagation() */
     passive: PropTypes.any,
   }


### PR DESCRIPTION
Brings back the onMove callback, ref: https://github.com/react-spring/react-with-gesture/issues/8